### PR TITLE
Remove load_plugin_textdomain()

### DIFF
--- a/elementor-hello-world.php
+++ b/elementor-hello-world.php
@@ -58,24 +58,8 @@ final class Elementor_Hello_World {
 	 */
 	public function __construct() {
 
-		// Load translation
-		add_action( 'init', array( $this, 'i18n' ) );
-
 		// Init Plugin
 		add_action( 'plugins_loaded', array( $this, 'init' ) );
-	}
-
-	/**
-	 * Load Textdomain
-	 *
-	 * Load plugin localization files.
-	 * Fired by `init` action hook.
-	 *
-	 * @since 1.2.0
-	 * @access public
-	 */
-	public function i18n() {
-		load_plugin_textdomain( 'elementor-hello-world' );
 	}
 
 	/**


### PR DESCRIPTION
No longer required since WordPress 4.6