### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elementor Hello World Sample Plugin
 
-This is a sample plugin to demonstrate how you can write extentions (plugins) to add custom functionality to [Elementor](https://github.com/pojome/elementor/)
+This is a sample plugin to demonstrate how you can write extensions (plugins) to add custom functionality to [Elementor](https://github.com/pojome/elementor/)
 
 Plugin Structure: 
 ```


### PR DESCRIPTION
Changes `extentions` to `extensions` in readme.